### PR TITLE
Acquire OnWaitFunc callback support for kubernetes locker

### DIFF
--- a/file_locker.go
+++ b/file_locker.go
@@ -57,7 +57,7 @@ func (locker *FileLocker) Acquire(lockName string, opts AcquireOptions) (bool, L
 	var wrappedOnWaitFunc func(doWait func() error) error
 	if opts.OnWaitFunc != nil {
 		wrappedOnWaitFunc = func(doWait func() error) error {
-			return opts.OnWaitFunc(lockHandle, doWait)
+			return opts.OnWaitFunc(lockName, doWait)
 		}
 	}
 

--- a/lockgate.go
+++ b/lockgate.go
@@ -24,7 +24,7 @@ type AcquireOptions struct {
 	Timeout     time.Duration
 	Shared      bool
 
-	OnWaitFunc      func(lock LockHandle, doWait func() error) error
+	OnWaitFunc      func(lockName string, doWait func() error) error
 	OnLostLeaseFunc func(lock LockHandle) error
 }
 


### PR DESCRIPTION
OnWaitFunc signature changed from `func(lock LockHandle, doWait func() error) error` to `func(lockName string, doWait func() error) error`, because at the wait moment lock-handle is not yet fully avaiable for the kubernetes locker.