### PR TITLE
Acquirer Queue

### DIFF
--- a/lockgate.go
+++ b/lockgate.go
@@ -23,6 +23,7 @@ type AcquireOptions struct {
 	NonBlocking bool
 	Timeout     time.Duration
 	Shared      bool
+	AcquirerId  string
 
 	OnWaitFunc      func(lockName string, doWait func() error) error
 	OnLostLeaseFunc func(lock LockHandle) error

--- a/pkg/distributed_locker/distributed_locker.go
+++ b/pkg/distributed_locker/distributed_locker.go
@@ -41,7 +41,7 @@ RETRY_ACQUIRE:
 		}
 	}
 
-	if lockHandle, err := l.Backend.Acquire(lockName, AcquireOptions{Shared: opts.Shared}); IsErrShouldWait(err) {
+	if lockHandle, err := l.Backend.Acquire(lockName, AcquireOptions{Shared: opts.Shared, AcquirerId: opts.AcquirerId}); IsErrShouldWait(err) {
 		if opts.NonBlocking {
 			debug("(acquire %q) non blocking acquire done: lock not taken!", lockName)
 			return false, lockgate.LockHandle{}, nil

--- a/pkg/distributed_locker/distributed_locker_backend.go
+++ b/pkg/distributed_locker/distributed_locker_backend.go
@@ -50,7 +50,8 @@ type DistributedLockerBackend interface {
 }
 
 type AcquireOptions struct {
-	Shared bool `json:"shared"`
+	Shared     bool   `json:"shared"`
+	AcquirerId string `json:"acquirerId"`
 }
 
 type LockLeaseRecord struct {
@@ -58,6 +59,13 @@ type LockLeaseRecord struct {
 	ExpireAtTimestamp  int64
 	SharedHoldersCount int64
 	IsShared           bool
+	QueueMembers       map[string]*QueueMember
+}
+
+type QueueMember struct {
+	AcquirerId          string
+	AcquiredAtTimestamp int64
+	ExpireAtTimestamp   int64
 }
 
 func NewLockLeaseRecord(lockName string, isShared bool) *LockLeaseRecord {
@@ -66,5 +74,6 @@ func NewLockLeaseRecord(lockName string, isShared bool) *LockLeaseRecord {
 		ExpireAtTimestamp:  time.Now().Unix() + DistributedLockLeaseTTLSeconds,
 		SharedHoldersCount: 1,
 		IsShared:           isShared,
+		QueueMembers:       make(map[string]*QueueMember),
 	}
 }

--- a/pkg/distributed_locker/optimistic_locking_storage_base_backend.go
+++ b/pkg/distributed_locker/optimistic_locking_storage_base_backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/werf/lockgate"
 	"github.com/werf/lockgate/pkg/distributed_locker/optimistic_locking_store"
 	"github.com/werf/lockgate/pkg/util"
@@ -38,24 +39,21 @@ RETRY_ACQUIRE:
 		} else if oldLease != nil {
 			debug("(acquire lock %q) oldLease -> %#v", lockName, oldLease)
 
+			// If the lease is expired, create a new lease for the caller if
+			// nobody else is waiting for they're first in line
 			if time.Now().After(time.Unix(oldLease.ExpireAtTimestamp, 0)) {
-				debug("(acquire lock %q) old lease expired, take over with the new lease!", lockName)
+				debug("(acquire lock %q) old lease expired, try to take over!", lockName)
 
-				newLease := NewLockLeaseRecord(lockName, opts.Shared)
-				debug("(acquire lock %q) new lease: %#v", lockName, newLease)
-
-				setLockLeaseIntoStoreValue(newLease, value)
-				if err := backend.Store.PutValue(storeKeyName, value); optimistic_locking_store.IsErrRecordVersionChanged(err) {
-					debug("(acquire lock %q update key %s optimistic locking error! Will retry acquire ...", lockName, storeKeyName)
-					time.Sleep(DistributedOptimisticLockingRetryPeriodSeconds * time.Second)
-					goto RETRY_ACQUIRE
-				} else if err != nil {
-					return lockgate.LockHandle{}, fmt.Errorf("unable to put store value by key %s: %s", storeKeyName, err)
+				if newLease, err := backend.TakeIfOldest(oldLease.LockHandle, opts.AcquirerId); err != nil {
+					debug("(acquire lock %q) failed %s", lockName, err.Error())
+					return lockgate.LockHandle{}, err
+				} else {
+					debug("(acquire lock %q) new lease: %#v", lockName, newLease)
+					return newLease.LockHandle, nil
 				}
-
-				return newLease.LockHandle, nil
 			}
 
+			// If caller wants a shared lease, and the existing lease is shared, give it to them
 			if opts.Shared && oldLease.IsShared {
 				oldLease.SharedHoldersCount++
 				oldLease.ExpireAtTimestamp = time.Now().Unix() + DistributedLockLeaseTTLSeconds
@@ -72,10 +70,15 @@ RETRY_ACQUIRE:
 
 				return oldLease.LockHandle, nil
 			}
+			// Keep acquirer's place in line by updating the expiration date
+			if err := backend.UpdateQueue(oldLease.LockHandle, opts.AcquirerId); err != nil {
+				return lockgate.LockHandle{}, err
+			}
 
 			return lockgate.LockHandle{}, ErrShouldWait
 		}
 
+		// No existing lease; create a new one
 		newLease := NewLockLeaseRecord(lockName, opts.Shared)
 		debug("(acquire lock %q) new lease: %#v", lockName, newLease)
 
@@ -100,15 +103,109 @@ func (backend *OptimisticLockingStorageBasedBackend) RenewLease(handle lockgate.
 	})
 }
 
+// If the acquirer is first in line or nobody else is waiting, update the lease with a new UUID.
+// If the acquirer is not first in line, they need to wait.
+func (backend *OptimisticLockingStorageBasedBackend) TakeIfOldest(handle lockgate.LockHandle, acquirerId string) (*LockLeaseRecord, error) {
+	var newLease *LockLeaseRecord
+	err := backend.changeLease(handle, func(value *optimistic_locking_store.Value, currentLease *LockLeaseRecord) error {
+		nextUp := &QueueMember{}
+		now := time.Now().Unix()
+		var expired []string
+		for k, l := range currentLease.QueueMembers {
+			if l.ExpireAtTimestamp < now {
+				expired = append(expired, l.AcquirerId)
+				continue
+			}
+			if k == acquirerId {
+				// Update expiration to hold acquirer's place in line
+				l.ExpireAtTimestamp = time.Now().Unix() + DistributedLockLeaseTTLSeconds
+			}
+			if nextUp.AcquiredAtTimestamp == 0 || l.AcquiredAtTimestamp < nextUp.AcquiredAtTimestamp {
+				nextUp = l
+			}
+		}
+		// Remove expired QueueMembers
+		for _, key := range expired {
+			delete(currentLease.QueueMembers, key)
+		}
+
+		if acquirerId != "" {
+			if _, ok := currentLease.QueueMembers[acquirerId]; !ok {
+				// Add new queue member
+				currentLease.QueueMembers[acquirerId] = &QueueMember{
+					AcquirerId:          acquirerId,
+					AcquiredAtTimestamp: time.Now().Unix(),
+					ExpireAtTimestamp:   time.Now().Unix() + DistributedLockLeaseTTLSeconds,
+				}
+			}
+		}
+
+		if nextUp.AcquirerId == "" || nextUp.AcquirerId == acquirerId {
+			// Generate a new UUID for the new acquirer
+			currentLease.UUID = uuid.New().String()
+			currentLease.ExpireAtTimestamp = time.Now().Unix() + DistributedLockLeaseTTLSeconds
+			currentLease.SharedHoldersCount = 1
+			delete(currentLease.QueueMembers, acquirerId)
+			newLease = currentLease
+		}
+		setLockLeaseIntoStoreValue(currentLease, value)
+
+		return nil
+	})
+	if err != nil {
+		return newLease, err
+	}
+	if newLease != nil {
+		return newLease, nil
+	}
+	return newLease, ErrShouldWait
+}
+
+// Renew queue member's expiration
+func (backend *OptimisticLockingStorageBasedBackend) UpdateQueue(handle lockgate.LockHandle, acquirerId string) error {
+	if acquirerId == "" {
+		return nil
+	}
+	return backend.changeLease(handle, func(value *optimistic_locking_store.Value, currentLease *LockLeaseRecord) error {
+		if _, ok := currentLease.QueueMembers[acquirerId]; ok {
+			currentLease.QueueMembers[acquirerId].ExpireAtTimestamp = time.Now().Unix() + DistributedLockLeaseTTLSeconds
+		} else {
+			currentLease.QueueMembers[acquirerId] = &QueueMember{
+				AcquirerId:          acquirerId,
+				AcquiredAtTimestamp: time.Now().Unix(),
+				ExpireAtTimestamp:   time.Now().Unix() + DistributedLockLeaseTTLSeconds,
+			}
+		}
+
+		setLockLeaseIntoStoreValue(currentLease, value)
+
+		return nil
+	})
+}
+
 func (backend *OptimisticLockingStorageBasedBackend) Release(handle lockgate.LockHandle) error {
 	return backend.changeLease(handle, func(value *optimistic_locking_store.Value, currentLease *LockLeaseRecord) error {
 		currentLease.SharedHoldersCount--
+		now := time.Now().Unix()
+		var expired []string
+		for _, l := range currentLease.QueueMembers {
+			if l.ExpireAtTimestamp < now {
+				expired = append(expired, l.AcquirerId)
+			}
+		}
+		for _, key := range expired {
+			delete(currentLease.QueueMembers, key)
+		}
 
 		if currentLease.SharedHoldersCount == 0 {
-			unsetLockLeaseFromStoreValue(value)
-		} else {
-			setLockLeaseIntoStoreValue(currentLease, value)
+			if len(currentLease.QueueMembers) == 0 {
+				unsetLockLeaseFromStoreValue(value)
+				return nil
+			}
+			// Expire the lease so the waiting QueueMembers can acquire it
+			currentLease.ExpireAtTimestamp = time.Now().Add(-1 * time.Second).Unix()
 		}
+		setLockLeaseIntoStoreValue(currentLease, value)
 
 		return nil
 	})


### PR DESCRIPTION
Add optional AcquirerId to AcquireOptions.  If passed, it will hold the acquirer's place in line if the requested lock is already held.

When the lock expires or is released, the next acquirer will be the one that has been waiting the longest.