### PR TITLE
Add HoldLease Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,15 @@ acquired, lockHandle, err := l.Acquire(lockName, lockgate.AcquireOptions{
 })
 ```
 
+`HoldLease` can be used renew a lease previously acquired.  This is useful when
+you want to block while waiting for a lease, then renew the lease in the background.
+
+```
+backend := distributed_locker.NewHttpBackend(serverUrl)
+l := distributed_locker.NewDistributedLocker(backend)
+l.HoldLease(lockName, uuid)
+```
+
 ## Lockgate HTTP lock server
 
 Lockgate HTTP server can use memory-storage or kubernetes-storage:


### PR DESCRIPTION
Add a HoldLease function that can be used to renew a lease acquired from a separate process.

This is useful when you want to block while waiting for a lease, then renew the lease in the background, e.g.

```
$ export LOCK=$(deploylock-client acquire -n lock-name https://lock-server/)
$ deploylock-client renew -n lock-name -l $LOCK https://lock-server/ &
$ <do work while holding lease>
```